### PR TITLE
chore(banner): use package env to get versions dynmically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,23 @@ rainbowcoat = "0.1.0"
 distance = "0.4.0"
 regex = "1.7.3"
 differ = "1.0.2"
+
+[profile.dev]
+opt-level = 0
+debug = true
+panic = "abort"
+
+[profile.test]
+opt-level = 0
+debug = true
+
+[profile.release]
+opt-level = 3
+debug = false
+panic = "unwind"
+lto = true
+codegen-units = 1
+
+[profile.bench]
+opt-level = 3
+debug = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,18 +31,22 @@ mod utils;
 
 // our fancy ascii banner to make it look hackery :D
 fn print_banner() {
-    const BANNER: &str = r#"                             
+    let pathbuster_version = env!("CARGO_PKG_VERSION");
+    let banner = format!(
+        r#"                             
                  __  __    __               __           
     ____  ____ _/ /_/ /_  / /_  __  _______/ /____  _____
    / __ \/ __ `/ __/ __ \/ __ \/ / / / ___/ __/ _ \/ ___/
   / /_/ / /_/ / /_/ / / / /_/ / /_/ (__  ) /_/  __/ /    
  / .___/\__,_/\__/_/ /_/_.___/\__,_/____/\__/\___/_/     
 /_/                                                          
-                     v0.5.5
+                     v{}
                      ------
         path normalization pentesting tool                       
-    "#;
-    write!(&mut rainbowcoat::stdout(), "{}", BANNER).unwrap();
+    "#,
+        pathbuster_version
+    );
+    write!(&mut rainbowcoat::stdout(), "{}", banner).unwrap();
     println!(
         "{}{}{} {}",
         "[".bold().white(),


### PR DESCRIPTION
Hey @ethicalhackingplayground, 

I just changed `pathbuster` to get the `version` dynamically to show in banner. Feel free to test and merge.

last time, it was conflicting with your branch and mine, so i had to rename branch nvm :D 

poc:

![foo](https://github.com/ethicalhackingplayground/pathbuster/assets/90331517/8ec27620-67c2-4617-a679-13ab0ce410b5)
